### PR TITLE
checker for adaptationSet.Representation

### DIFF
--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -77,7 +77,7 @@ export class Util extends null {
         })
 
         for (const adaptationSet of xml.MPD.Period.AdaptationSet) {
-            for (const representation of adaptationSet.Representation) {
+            for (const representation of Array.isArray(adaptationSet.Representation) ? adaptationSet.Representation : [adaptationSet.Representation]) {
                 const itag = Number(representation["$id"]) as keyof typeof formats
                 const reservedFormat = formats[itag]
 


### PR DESCRIPTION
now we check if adaptationSet.Representation is an array or not
cause for some tracks formats it receive object and not array of object

this image shows the error
![image](https://user-images.githubusercontent.com/73595362/155287248-3f04d716-fd4e-4720-b96f-1e178570e0d5.png)

on debugging via  `console.log({a:adaptationSet.Representation})`
![image](https://user-images.githubusercontent.com/73595362/155287619-11c62cb2-ee23-4dc3-80b9-90f633ac3b6f.png)
![image](https://user-images.githubusercontent.com/73595362/155287637-6a9206ed-1fbd-4aa7-81f8-3074faaabdb0.png)

